### PR TITLE
Fix: Ensure correct URL construction for Discourse instances with sub…

### DIFF
--- a/src/__tests__/crawling.test.ts
+++ b/src/__tests__/crawling.test.ts
@@ -141,4 +141,86 @@ describe('DiscourseCrawler', () => {
       expect(mockDb.close).toHaveBeenCalled()
     })
   })
+
+  describe('crawl with subpath', () => {
+    it('should construct URLs correctly when base URL has a subpath', async () => {
+      const baseUrlWithSubpath = 'http://localhost:4200/testforum'
+      // The constructor normalizes by adding a trailing slash if there's a pathname
+      const normalizedBaseUrl = 'http://localhost:4200/testforum/'
+      const expectedCategoriesUrl = 'http://localhost:4200/testforum/categories.json'
+      // Assuming category ID 1, page 0 for the first category page fetch
+      const expectedCategory1Url = 'http://localhost:4200/testforum/c/1.json?page=0'
+
+      const mockedAxiosGet = vi.mocked(axios.get)
+
+      mockedAxiosGet.mockImplementation(async (url: string) => {
+        // console.log(`axios.get mock called with: ${url}`) // For debugging
+        if (url === expectedCategoriesUrl) {
+          return Promise.resolve({
+            data: {
+              category_list: {
+                categories: [
+                  { id: 1, topic_url: 't/category-1/1', slug: 'category-1', name: 'Category 1' },
+                ],
+              },
+            },
+          })
+        }
+        if (url === expectedCategory1Url) {
+          return Promise.resolve({
+            data: {
+              topic_list: { topics: [], more_topics_url: null },
+            },
+          })
+        }
+        // Fallback for any other URLs, like topic.json or posts.json, which we are not specifically testing here
+        return Promise.resolve({ data: { post_stream: { posts: [], stream: [] } } })
+      })
+
+      const mockDbInstance = {
+        findForum: vi.fn().mockResolvedValue(null),
+        createForum: vi.fn().mockResolvedValue({ id: 1, url: normalizedBaseUrl, categories_crawled: false }),
+        updateForum: vi.fn().mockResolvedValue(undefined),
+        createCategory: vi.fn().mockResolvedValue({ id: 1, category_id: 1, forum_id: 1, pages_crawled: false, topic_url: 't/category-1/1' }),
+        // This will be called twice: once before categories created (empty), once after for crawlCategory loop
+        findCategoriesByForumId: vi.fn()
+          .mockResolvedValueOnce([]) // Initial call in crawlForum before categories are processed
+          .mockResolvedValueOnce([{ id: 1, category_id: 1, forum_id: 1, pages_crawled: false, topic_url: 't/category-1/1', json: '{}' }]), // For the crawlCategory loop
+        getLastPageByCategory: vi.fn().mockResolvedValue(null),
+        createPage: vi.fn().mockResolvedValue({ id: 1, page_id: 0, more_topics_url: null }),
+        updateCategory: vi.fn().mockResolvedValue(undefined),
+        getTopicsByCategoryId: vi.fn().mockResolvedValue([]), // No topics to crawl for simplicity
+        getLatestTopicTimestamp: vi.fn().mockResolvedValue(null), // No existing data
+        findTopicByCategoryIdAndTopicId: vi.fn().mockResolvedValue(null),
+        close: vi.fn(),
+        query: vi.fn().mockResolvedValue(undefined) // For resetCrawledState if fullCrawl is used
+      }
+      vi.mocked(Database.create).mockResolvedValue(mockDbInstance as any)
+
+      const crawler = await DiscourseCrawler.create(baseUrlWithSubpath, 'test-subpath.db', { rateLimit: 0 }) // rateLimit 0 to speed up test
+      await crawler.crawl()
+
+      // Verify createForum was called with the normalized URL
+      expect(mockDbInstance.createForum).toHaveBeenCalledWith({
+        url: normalizedBaseUrl,
+        categories_crawled: false,
+      })
+
+      // Verify axios.get was called for categories.json
+      expect(mockedAxiosGet).toHaveBeenCalledWith(expectedCategoriesUrl)
+
+      // Verify axios.get was called for the first category's page
+      expect(mockedAxiosGet).toHaveBeenCalledWith(expectedCategory1Url)
+      
+      // Check that createCategory was called for category 1
+      expect(mockDbInstance.createCategory).toHaveBeenCalledWith(
+        expect.objectContaining({ category_id: 1, forum_id: 1 })
+      );
+
+      // Check that createPage was called for category 1, page 0
+      expect(mockDbInstance.createPage).toHaveBeenCalledWith(
+        expect.objectContaining({ category_id: 1, page_id: 0 })
+      );
+    })
+  })
 })


### PR DESCRIPTION
…paths

The crawler was previously not handling base URLs with subpaths correctly, leading to incorrect URL construction for API endpoints. This typically resulted in 404 errors as requests were made to the domain root instead of the subpath.

This commit addresses the issue by:
1. Normalizing the `baseUrl` in the `DiscourseCrawler` constructor to ensure it always has a trailing slash if a path component exists (e.g., `http://example.com/forum` becomes `http://example.com/forum/`).
2. Adjusting the construction of `categories.json` URL in `crawlForum` to use `new URL('categories.json', forum.url)`, ensuring correct relative path joining.
3. Verifying and confirming that other URL constructions (for category pages, topic links, etc.) correctly use the normalized `baseUrl` or absolute paths as appropriate. The use of `new URL('path/relative/to/base', baseUrl)` and direct `pathname` assignments were reviewed.

A new test case has been added to `crawling.test.ts` to specifically verify that URLs are constructed correctly when the crawler is initialized with a base URL containing a subpath (e.g., `http://example.com/forum`). This test mocks HTTP requests and database interactions to confirm that API endpoints like `categories.json` and category pages are targeted at the correct subpath.


btw cool work ;) 