### PR TITLE
Fixes missing subpath capabilities

### DIFF
--- a/src/__tests__/crawling.test.ts
+++ b/src/__tests__/crawling.test.ts
@@ -141,4 +141,86 @@ describe('DiscourseCrawler', () => {
       expect(mockDb.close).toHaveBeenCalled()
     })
   })
+
+  describe('crawl with subpath', () => {
+    it('should construct URLs correctly when base URL has a subpath', async () => {
+      const baseUrlWithSubpath = 'http://localhost:4200/testforum'
+      // The constructor normalizes by adding a trailing slash if there's a pathname
+      const normalizedBaseUrl = 'http://localhost:4200/testforum/'
+      const expectedCategoriesUrl = 'http://localhost:4200/testforum/categories.json'
+      // Assuming category ID 1, page 0 for the first category page fetch
+      const expectedCategory1Url = 'http://localhost:4200/testforum/c/1.json?page=0'
+
+      const mockedAxiosGet = vi.mocked(axios.get)
+
+      mockedAxiosGet.mockImplementation(async (url: string) => {
+        // console.log(`axios.get mock called with: ${url}`) // For debugging
+        if (url === expectedCategoriesUrl) {
+          return Promise.resolve({
+            data: {
+              category_list: {
+                categories: [
+                  { id: 1, topic_url: 't/category-1/1', slug: 'category-1', name: 'Category 1' },
+                ],
+              },
+            },
+          })
+        }
+        if (url === expectedCategory1Url) {
+          return Promise.resolve({
+            data: {
+              topic_list: { topics: [], more_topics_url: null },
+            },
+          })
+        }
+        // Fallback for any other URLs, like topic.json or posts.json, which we are not specifically testing here
+        return Promise.resolve({ data: { post_stream: { posts: [], stream: [] } } })
+      })
+
+      const mockDbInstance = {
+        findForum: vi.fn().mockResolvedValue(null),
+        createForum: vi.fn().mockResolvedValue({ id: 1, url: normalizedBaseUrl, categories_crawled: false }),
+        updateForum: vi.fn().mockResolvedValue(undefined),
+        createCategory: vi.fn().mockResolvedValue({ id: 1, category_id: 1, forum_id: 1, pages_crawled: false, topic_url: 't/category-1/1' }),
+        // This will be called twice: once before categories created (empty), once after for crawlCategory loop
+        findCategoriesByForumId: vi.fn()
+          .mockResolvedValueOnce([]) // Initial call in crawlForum before categories are processed
+          .mockResolvedValueOnce([{ id: 1, category_id: 1, forum_id: 1, pages_crawled: false, topic_url: 't/category-1/1', json: '{}' }]), // For the crawlCategory loop
+        getLastPageByCategory: vi.fn().mockResolvedValue(null),
+        createPage: vi.fn().mockResolvedValue({ id: 1, page_id: 0, more_topics_url: null }),
+        updateCategory: vi.fn().mockResolvedValue(undefined),
+        getTopicsByCategoryId: vi.fn().mockResolvedValue([]), // No topics to crawl for simplicity
+        getLatestTopicTimestamp: vi.fn().mockResolvedValue(null), // No existing data
+        findTopicByCategoryIdAndTopicId: vi.fn().mockResolvedValue(null),
+        close: vi.fn(),
+        query: vi.fn().mockResolvedValue(undefined) // For resetCrawledState if fullCrawl is used
+      }
+      vi.mocked(Database.create).mockResolvedValue(mockDbInstance as any)
+
+      const crawler = await DiscourseCrawler.create(baseUrlWithSubpath, 'test-subpath.db', { rateLimit: 0 }) // rateLimit 0 to speed up test
+      await crawler.crawl()
+
+      // Verify createForum was called with the normalized URL
+      expect(mockDbInstance.createForum).toHaveBeenCalledWith({
+        url: normalizedBaseUrl,
+        categories_crawled: false,
+      })
+
+      // Verify axios.get was called for categories.json
+      expect(mockedAxiosGet).toHaveBeenCalledWith(expectedCategoriesUrl)
+
+      // Verify axios.get was called for the first category's page
+      expect(mockedAxiosGet).toHaveBeenCalledWith(expectedCategory1Url)
+      
+      // Check that createCategory was called for category 1
+      expect(mockDbInstance.createCategory).toHaveBeenCalledWith(
+        expect.objectContaining({ category_id: 1, forum_id: 1 })
+      );
+
+      // Check that createPage was called for category 1, page 0
+      expect(mockDbInstance.createPage).toHaveBeenCalledWith(
+        expect.objectContaining({ category_id: 1, page_id: 0 })
+      );
+    })
+  })
 })


### PR DESCRIPTION
The library was not able to handle a URL that includes a sub-path, so I fixed this to be able to crawl e.g.

`somedomain.com/forum`